### PR TITLE
add fixes for macos

### DIFF
--- a/src/Signals.c
+++ b/src/Signals.c
@@ -7,6 +7,10 @@
 SLCL_ENTERCPP
 #endif
 
+#if defined(SLCL_TARGET_DARWIN)
+typedef void* __sighandler_t;
+#endif
+
 #if defined(SLCL_TARGET_WIN)
 #include <signal.h>
 


### PR DESCRIPTION
Fixes: #3

Removes non-mac compatible socket protocols to allow macOS compatibility

The only protocol removed that isn't already non-existent in windows is the AF_BLUETOOTH protocol